### PR TITLE
Remove unnecessary module in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ prettytable>=3.5
 pefile
 cabarchive
 pywin32
-python-magic
-python-magic-bin; sys_platform == "win32" or sys_platform == "darwin"
+python-magic-bin
 
 # ssdeep is optional
 #ssdeep 


### PR DESCRIPTION
Because this "script can only be used in Windows system", we can remove unnecessary module.  
In fact, installing both python-magic and python-magic-bin at the same time will result in an error: the script will quit quiet.  